### PR TITLE
alt buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,13 @@
 				<track label="captions" kind="subtitles" srclang="en" src="video/captions.vtt" default>
 			</video>
 			<div id="controls-container" class="lowered">
+				
 				<progress id="buffer" value="0" max="100"></progress>
-				<progress id="progress" value="0" max="100"></progress>
+				<div id="progress">
+					<div id="progress-bar"></div>
+				</div>
+
+				
 				<div id="controls-buttons" class="hidden">
 					<button id="playpause" type="button"></button>
 					<div id="timer"></div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -2,8 +2,10 @@ var video = document.getElementById('video');
 var controlsContainer = document.getElementById('controls-container');
 var controlsButtons = document.getElementById('controls-buttons');
 var buffer = document.getElementById('buffer');
+
 var timeDrag = false;
 var progress = document.getElementById('progress');
+var progressBar = document.getElementById('progress-bar');
 var playpause = document.getElementById('playpause');
 var timer = document.getElementById('timer');
 var endTime = document.getElementById('end-time');
@@ -20,30 +22,18 @@ var caption = document.getElementsByClassName('caption');
 
 function progressPopulate() {
 	var videoTime = ((video.currentTime / video.duration) * 100);
-	progress.value = videoTime;
+	progressBar.style.width = videoTime + '%';
 }
 
 video.addEventListener('timeupdate', progressPopulate);
 
+
 // *** BUFFER BAR ***
-/*
-function timeOut(e, i) {
-	setTimeout(e, i);
-}
-
-function startBuffer() {
-	var currentBuffer = ((video.buffered.end(0) / video.duration) * 100);
-	console.log(video.buffered.end(0));
-	console.log(currentBuffer);
-	buffer.value = currentBuffer;
-}
-
-video.addEventListener('progress', timeOut(startBuffer, 500));
-*/
 
 function bufferPopulate() {
 	var currentBuffer = ((video.buffered.end(0) / video.duration) * 100);
 	buffer.value = currentBuffer;
+	console.log(currentBuffer);
 }
 
 video.addEventListener('progress', bufferPopulate);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -89,15 +89,23 @@
 /* moves buffer bar under progress bar */
 #buffer {
 	margin-bottom: -4px;
+	z-index: 10;
+}
+
+#progress-bar {
+	height: 100%;
+	width: 0%;
+	z-index: 12;
+	background-color: orange;
 }
 
 /* gives progress bar +1 higher index than other controls */
 #progress {
+	background: transparent; 
 	z-index: 11;
 }
 
 
-#progress[value],
 #buffer[value] {
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -105,7 +113,7 @@
 	border: none;
 }
 
-
+/* Styles for progress element as buffer display 
 #progress::-webkit-progress-bar {
 	background: transparent;
 }
@@ -117,7 +125,7 @@
 #progress::-moz-progress-bar {
 	background-color: orange;
 }
-
+*/
 
 #buffer::-webkit-progress-bar {
 	background-color: rgba(255, 255, 255, 0.4);	
@@ -130,6 +138,7 @@
 #buffer::-moz-progress-bar {
 	background-color: #FFF1D6;
 }
+
 
 
 /* CONTROLS BUTTONS AND TIMER STYLES */


### PR DESCRIPTION
changed progress bar from a progress element to nested divs.

Firefox does not allow styling of the progress element. Therefore I
could not set the progress bar’s background to be transparent, showing
the buffer bar, unless I made it nested divs rather than a progress
element.
